### PR TITLE
Feature to write exact number of objects in Put.

### DIFF
--- a/cli/put.go
+++ b/cli/put.go
@@ -36,6 +36,11 @@ var putFlags = []cli.Flag{
 		Usage:  "Multipart part size. Can be a number or 10KiB/MiB/GiB. All sizes are base 2 binary.",
 		Hidden: true,
 	},
+	cli.IntFlag{
+		Name:  "objects",
+		Value: 2500,
+		Usage: "Number of objects to upload.",
+	},
 }
 
 // Put command.
@@ -60,8 +65,10 @@ FLAGS:
 // mainPut is the entry point for cp command.
 func mainPut(ctx *cli.Context) error {
 	checkPutSyntax(ctx)
+	//err := Generate(ctx.Int("objects") * 2)
 	b := bench.Put{
-		Common: getCommon(ctx, newGenSource(ctx, "obj.size")),
+		Common:        getCommon(ctx, newGenSource(ctx, "obj.size")),
+		CreateObjects: ctx.Int("objects"),
 	}
 	return runBench(ctx, &b)
 }

--- a/pkg/build-constants.go
+++ b/pkg/build-constants.go
@@ -19,7 +19,7 @@ package pkg
 
 var (
 	// Version - the version being released (v prefix stripped)
-	Version = "v0.7.4-without-analyze"
+	Version = "v0.7.7-without-analyze"
 	// ReleaseTag - the current git tag
 	ReleaseTag = ""
 	// ReleaseTime - current UTC date in RFC3339 format.


### PR DESCRIPTION
Added a feature to write the defined number of objects as seen with mixed workload. This will allow users to control a precise number of objects for the fill workload can't be used simultaneously with duration.

Signed-off-by: shreyanshjain7174 [ssanchet@redhat.com](mailto:ssanchet@redhat.com)