### PR TITLE
Feature to write exact number of objects in Put.

### DIFF
--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -53,7 +53,7 @@ var benchFlags = []cli.Flag{
 	cli.DurationFlag{
 		Name:  "duration",
 		Usage: "Duration to run the benchmark. Use 's' and 'm' to specify seconds and minutes.",
-		Value: 5 * time.Minute,
+		Value: 48 * time.Hour,
 	},
 	cli.BoolFlag{
 		Name:  "autoterm",

--- a/cli/put.go
+++ b/cli/put.go
@@ -36,6 +36,11 @@ var putFlags = []cli.Flag{
 		Usage:  "Multipart part size. Can be a number or 10KiB/MiB/GiB. All sizes are base 2 binary.",
 		Hidden: true,
 	},
+	cli.IntFlag{
+		Name:  "objects",
+		Value: 2500,
+		Usage: "Number of objects to upload.",
+	},
 }
 
 // Put command.
@@ -60,8 +65,10 @@ FLAGS:
 // mainPut is the entry point for cp command.
 func mainPut(ctx *cli.Context) error {
 	checkPutSyntax(ctx)
+	//err := Generate(ctx.Int("objects") * 2)
 	b := bench.Put{
-		Common: getCommon(ctx, newGenSource(ctx, "obj.size")),
+		Common:        getCommon(ctx, newGenSource(ctx, "obj.size")),
+		CreateObjects: ctx.Int("objects"),
 	}
 	return runBench(ctx, &b)
 }

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	github.com/minio/pkg v1.7.5
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEp
 github.com/minio/minio-go/v7 v7.0.66 h1:bnTOXOHjOqv/gcMuiVbN9o2ngRItvqE774dG9nq0Dzw=
 github.com/minio/minio-go/v7 v7.0.66/go.mod h1:DHAgmyQEGdW3Cif0UooKOyrT3Vxs82zNdV6tkKhRtbs=
 github.com/minio/mux v1.9.0 h1:dWafQFyEfGhJvK6AwLOt83bIG5bxKxKJnKMCi0XAaoA=
+github.com/minio/pkg v1.7.5 h1:UOUJjewE5zoaDPlCMJtNx/swc1jT1ZR+IajT7hrLd44=
+github.com/minio/pkg v1.7.5/go.mod h1:mEfGMTm5Z0b5EGxKNuPwyb5A2d+CC/VlUyRj6RJtIwo=
 github.com/minio/pkg/v2 v2.0.6 h1:n+PpbSMaJK1FfQkP55l1y0wj5Hi9R5w2DtGhxiGdP9I=
 github.com/minio/pkg/v2 v2.0.6/go.mod h1:Z9Z/LzhTIxZ6zhPeW658vmLRilRek3zBOqNB9j+lxSY=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -23,12 +23,42 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/minio/pkg/console"
+	"github.com/minio/warp/pkg/generator"
 )
 
 // Put benchmarks upload speed.
 type Put struct {
 	Common
-	prefixes map[string]struct{}
+	prefixes      map[string]struct{}
+	CreateObjects int
+}
+
+// PutOpts are options for PutObject.
+type PutOpts struct {
+	objects map[string]generator.Object
+}
+
+func (m *PutOpts) Generate(allocObjs int) error {
+
+	m.objects = make(map[string]generator.Object, allocObjs)
+	for i := 0; i < allocObjs; i++ {
+		obj := generator.Object{
+			Name:        fmt.Sprintf("obj-%d", i),
+			ContentType: "application/octet-stream",
+		}
+		m.objects[obj.Name] = obj
+	}
+	return nil
+}
+
+func (m *PutOpts) Objects() generator.Objects {
+	res := make(generator.Objects, 0, len(m.objects))
+	for _, v := range m.objects {
+		res = append(res, v)
+	}
+	return res
 }
 
 // Prepare will create an empty bucket ot delete any content already there.
@@ -39,7 +69,11 @@ func (u *Put) Prepare(ctx context.Context) error {
 // Start will execute the main benchmark.
 // Operations should begin executing when the start channel is closed.
 func (u *Put) Start(ctx context.Context, wait chan struct{}) (Operations, error) {
+	src := u.Source()
 	var wg sync.WaitGroup
+	if u.CreateObjects != 2500 && ctx.Value("duration") != 5*time.Minute {
+		console.Info("\rUploading ", u.CreateObjects*u.Concurrency, " objects of ", src.String())
+	}
 	wg.Add(u.Concurrency)
 	u.addCollector()
 	c := u.Collector
@@ -47,10 +81,14 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 		ctx = c.AutoTerm(ctx, http.MethodPut, u.AutoTermScale, autoTermCheck, autoTermSamples, u.AutoTermDur)
 	}
 	u.prefixes = make(map[string]struct{}, u.Concurrency)
-
+	obj := make(chan struct{}, u.CreateObjects)
+	for i := 0; i < u.CreateObjects; i++ {
+		obj <- struct{}{}
+	}
+	close(obj)
 	// Non-terminating context.
 	nonTerm := context.Background()
-
+	objectcount := 0
 	for i := 0; i < u.Concurrency; i++ {
 		src := u.Source()
 		u.prefixes[src.Prefix()] = struct{}{}
@@ -98,6 +136,10 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 				op.Size = res.Size
 				cldone()
 				rcv <- op
+				objectcount++
+				if objectcount == u.CreateObjects {
+					return
+				}
 			}
 		}(i)
 	}

--- a/pkg/build-constants.go
+++ b/pkg/build-constants.go
@@ -19,7 +19,7 @@ package pkg
 
 var (
 	// Version - the version being released (v prefix stripped)
-	Version = "v0.7.4-without-analyze"
+	Version = "v0.7.7-without-analyze"
 	// ReleaseTag - the current git tag
 	ReleaseTag = ""
 	// ReleaseTime - current UTC date in RFC3339 format.


### PR DESCRIPTION
Added a feature to write the defined number of objects as seen with mixed workload. This will allow users to control a precise nnumber of objects for the fill workload can't be used simultaneously with duration.